### PR TITLE
Remove devnet support

### DIFF
--- a/packages/example/src/containers/Dashboard/Dashboard.tsx
+++ b/packages/example/src/containers/Dashboard/Dashboard.tsx
@@ -23,12 +23,12 @@ export const Dashboard = () => {
 
     const [balanceChange, setBalanceChange] = useState<boolean>(false);
 
-    const [network, setNetwork] = useState<"f" | "t" | "d">("d");
+    const [network, setNetwork] = useState<"f" | "t" >("t");
 
     const [api, setApi] = useState<FilecoinSnapApi|null>(null);
 
     const handleNetworkChange = async (event: React.ChangeEvent<{value: any}>) => {
-        const selectedNetwork = event.target.value as "f" | "t" | "d";
+        const selectedNetwork = event.target.value as "f" | "t";
         if (selectedNetwork === network) return;
         if (api) {
             await api.configure({network: selectedNetwork});
@@ -99,12 +99,11 @@ export const Dashboard = () => {
                     <Box m="1rem" alignSelf="baseline">
                         <InputLabel>Network</InputLabel>
                         <Select
-                            defaultValue={"d"}
+                            defaultValue={"t"}
                             onChange={handleNetworkChange}
                         >
                             <MenuItem value={"t"}>Testnet</MenuItem>
                             {/*<MenuItem value={"f"}>Mainnet</MenuItem> - mainnet not supported*/}
-                            <MenuItem value={"d"}>Devnnet</MenuItem>
                         </Select>
                     </Box>
                     <Grid container spacing={3} alignItems="stretch">

--- a/packages/example/src/services/metamask.ts
+++ b/packages/example/src/services/metamask.ts
@@ -27,9 +27,9 @@ export async function installFilecoinSnap(): Promise<SnapInitializationResponse>
         console.log("installing snap");
         let metamaskFilecoinSnap;
         if (process.env.REACT_APP_SNAP === 'local') {
-            metamaskFilecoinSnap = await enableFilecoinSnap({network: "d"}, localOrigin);
+            metamaskFilecoinSnap = await enableFilecoinSnap({network: "t"}, localOrigin);
         } else {
-            metamaskFilecoinSnap = await enableFilecoinSnap({network: "d"});
+            metamaskFilecoinSnap = await enableFilecoinSnap({network: "t"});
         }
         isInstalled = true;
         console.log("Snap installed!!");

--- a/packages/snap/src/configuration/index.ts
+++ b/packages/snap/src/configuration/index.ts
@@ -1,7 +1,6 @@
 import {Wallet} from "../interfaces";
 import {
   defaultConfiguration,
-  filecoinDevnetConfiguration,
   filecoinMainnetConfiguration,
   filecoinTestnetConfiguration
 } from "./predefined";
@@ -15,9 +14,6 @@ export function getDefaultConfiguration(networkName?: string): SnapConfig {
     case "t":
       console.log("Filecoin testnet network selected");
       return filecoinTestnetConfiguration;
-    case "d":
-      console.log("Filecoin devnet network selected");
-      return filecoinDevnetConfiguration;
     default:
       return defaultConfiguration;
   }

--- a/packages/snap/src/configuration/predefined.ts
+++ b/packages/snap/src/configuration/predefined.ts
@@ -14,22 +14,6 @@ export const filecoinMainnetConfiguration: SnapConfig = {
   }
 };
 
-export const filecoinDevnetConfiguration: SnapConfig = {
-  derivationPath: "m/44'/1'/0'/0/0",
-  network: "t",
-  rpc: {
-    // eslint-disable-next-line max-len
-    token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.DstNwIKa86Ftmz_zn9uJ3e_EBAd-Ot0-0tDHzl4YVP4",
-    url: `http://134.122.86.62:1234/rpc/v0`,
-  },
-  unit: {
-    decimals: 6,
-    image: `https://svgshare.com/i/M4s.svg`,
-    symbol: "FIL",
-    // custom view url ?
-  }
-};
-
 // devnet configuration replaces testnet for now
 export const filecoinTestnetConfiguration: SnapConfig = {
   derivationPath: "m/44'/1'/0'/0/0",

--- a/packages/snap/src/rpc/configure.ts
+++ b/packages/snap/src/rpc/configure.ts
@@ -6,7 +6,6 @@ import {SnapConfig} from "@nodefactory/filsnap-types";
 export function configure(wallet: Wallet, networkName: string, overrides?: unknown): SnapConfig {
   const defaultConfig = getDefaultConfiguration(networkName);
   const configuration = overrides ? deepmerge(defaultConfig, overrides) : defaultConfig;
-  configuration.network = networkName === "d" ? "t" : configuration.network;
   const state = wallet.getPluginState();
   state.filecoin.config = configuration;
   wallet.updatePluginState(state);

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -145,7 +145,7 @@ export interface MessageStatus {
   cid: string;
 }
 
-export type FilecoinNetwork = "f" | "t" | "d";
+export type FilecoinNetwork = "f" | "t";
 
 export interface FilecoinEventApi {}
 


### PR DESCRIPTION
As now Filecoin testnet nodes are stable, we are removing support for our hosted devnet as this was temporary solution from the begining.

@kumavis probably something you should know

### Changes
- Removed devnet configuration
- Removed devnet from example app

