### PR TITLE
Prefix RPC methods

### DIFF
--- a/packages/adapter/src/methods.ts
+++ b/packages/adapter/src/methods.ts
@@ -17,43 +17,43 @@ async function sendSnapMethod<T>(request: MetamaskFilecoinRpcRequest, snapId: st
 }
 
 export async function getAddress(this: MetamaskFilecoinSnap): Promise<string> {
-  return await sendSnapMethod({method: "getAddress"}, this.snapId);
+  return await sendSnapMethod({method: "fil_getAddress"}, this.snapId);
 }
 
 export async function getPublicKey(this: MetamaskFilecoinSnap): Promise<string> {
-  return await sendSnapMethod({method: "getPublicKey"}, this.snapId);
+  return await sendSnapMethod({method: "fil_getPublicKey"}, this.snapId);
 }
 
 export async function getBalance(this: MetamaskFilecoinSnap): Promise<string> {
-  return await sendSnapMethod({method: "getBalance"}, this.snapId);
+  return await sendSnapMethod({method: "fil_getBalance"}, this.snapId);
 }
 
 export async function exportPrivateKey(this: MetamaskFilecoinSnap): Promise<string> {
-  return await sendSnapMethod({method: "exportPrivateKey"}, this.snapId);
+  return await sendSnapMethod({method: "fil_exportPrivateKey"}, this.snapId);
 }
 
 export async function configure(this: MetamaskFilecoinSnap, configuration: SnapConfig): Promise<void> {
-  return await sendSnapMethod({method: "configure", params: {configuration: configuration}}, this.snapId);
+  return await sendSnapMethod({method: "fil_configure", params: {configuration: configuration}}, this.snapId);
 }
 
 export async function signMessage(this: MetamaskFilecoinSnap, message: MessageRequest): Promise<SignedMessage> {
-  return await sendSnapMethod({method: "signMessage", params: {message: message}}, this.snapId);
+  return await sendSnapMethod({method: "fil_signMessage", params: {message: message}}, this.snapId);
 }
 
 export async function signMessageRaw(this: MetamaskFilecoinSnap, rawMessage: string): Promise<string> {
-  return await sendSnapMethod({method: "signMessageRaw", params: {message: rawMessage}}, this.snapId);
+  return await sendSnapMethod({method: "fil_signMessageRaw", params: {message: rawMessage}}, this.snapId);
 }
 
 export async function sendMessage(this: MetamaskFilecoinSnap, signedMessage: SignedMessage): Promise<MessageStatus> {
-  return await sendSnapMethod({method: "sendMessage", params: {signedMessage: signedMessage}}, this.snapId);
+  return await sendSnapMethod({method: "fil_sendMessage", params: {signedMessage: signedMessage}}, this.snapId);
 }
 
 export async function getMessages(this: MetamaskFilecoinSnap): Promise<MessageStatus[]> {
-  return await sendSnapMethod({method: "getMessages"}, this.snapId);
+  return await sendSnapMethod({method: "fil_getMessages"}, this.snapId);
 }
 
 export async function calculateGasForMessage(
   this: MetamaskFilecoinSnap, message: MessageRequest
 ): Promise<MessageGasEstimate> {
-  return await sendSnapMethod({method: "getGasForMessage", params: {message: message}}, this.snapId);
+  return await sendSnapMethod({method: "fil_getGasForMessage", params: {message: message}}, this.snapId);
 }

--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -16,7 +16,7 @@ import {estimateMessageGas} from "./rpc/estimateMessageGas";
 declare let wallet: Wallet;
 
 const apiDependentMethods = [
-  "getBalance", "signMessage", "sendMessage", "getGasForMessage"
+  "fil_getBalance", "fil_signMessage", "fil_sendMessage", "fil_getGasForMessage"
 ];
 
 wallet.registerApiRequestHandler(async function (origin: URL): Promise<FilecoinEventApi> {
@@ -37,32 +37,32 @@ wallet.registerRpcMessageHandler(async (originString, requestObject) => {
   }
 
   switch (requestObject.method) {
-    case "configure":
+    case "fil_configure":
       const configuration = configure(
         wallet, requestObject.params.configuration.network, requestObject.params.configuration
       );
       api = getApi(wallet);
       await updateAsset(wallet, originString, await getBalance(wallet, api));
       return configuration;
-    case "getAddress":
+    case "fil_getAddress":
       return await getAddress(wallet);
-    case "getPublicKey":
+    case "fil_getPublicKey":
       return await getPublicKey(wallet);
-    case "exportPrivateKey":
+    case "fil_exportPrivateKey":
       return exportPrivateKey(wallet);
-    case "getBalance":
+    case "fil_getBalance":
       const balance = await getBalance(wallet, api);
       await updateAsset(wallet, originString, balance);
       return balance;
-    case "getMessages":
+    case "fil_getMessages":
       return getMessages(wallet);
-    case "signMessage":
+    case "fil_signMessage":
       return await signMessage(wallet, api, requestObject.params.message);
-    case "signMessageRaw":
+    case "fil_signMessageRaw":
       return await signMessageRaw(wallet, requestObject.params.message);
-    case "sendMessage":
+    case "fil_sendMessage":
       return await sendMessage(wallet, api, requestObject.params.signedMessage);
-    case "getGasForMessage":
+    case "fil_getGasForMessage":
       return await estimateMessageGas(wallet, api, requestObject.params.message);
     default:
       throw new Error("Unsupported RPC method");

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -1,53 +1,53 @@
 export interface GetPublicKeyRequest{
-  method: "getPublicKey";
+  method: "fil_getPublicKey";
 }
 
 export interface GetAddressRequest {
-  method: "getAddress";
+  method: "fil_getAddress";
 }
 
 export interface ExportSeedRequest {
-  method: "exportPrivateKey";
+  method: "fil_exportPrivateKey";
 }
 
 export interface ConfigureRequest {
-  method: "configure";
+  method: "fil_configure";
   params: {
     configuration: SnapConfig;
   };
 }
 
 export interface SignMessageRequest {
-  method: "signMessage";
+  method: "fil_signMessage";
   params: {
     message: MessageRequest;
   };
 }
 
 export interface SignMessageRawRequest {
-  method: "signMessageRaw";
+  method: "fil_signMessageRaw";
   params: {
     message: string;
   };
 }
 
 export interface SendMessageRequest {
-  method: "sendMessage";
+  method: "fil_sendMessage";
   params: {
     signedMessage: SignedMessage;
   };
 }
 
 export interface GetBalanceRequest {
-  method: "getBalance";
+  method: "fil_getBalance";
 }
 
 export interface GetMessagesRequest {
-  method: "getMessages";
+  method: "fil_getMessages";
 }
 
 export interface GetGasForMessageRequest {
-  method: "getGasForMessage";
+  method: "fil_getGasForMessage";
   params: {
     message: MessageRequest;
   };


### PR DESCRIPTION
### Changes
- Prefix all RPC methods with `fil_`

### Issues
closes #67 