### PR TITLE
Publish version v0.2.2 of packages

### DIFF
--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodefactory/filsnap-adapter",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "./build/index.js",
   "module": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -2,7 +2,7 @@ import {hasMetaMask, isMetamaskSnapsSupported, isSnapInstalled} from "./utils";
 import {MetamaskFilecoinSnap as MFSnap} from "./snap";
 import {SnapConfig} from "@nodefactory/filsnap-types";
 
-const defaultSnapOrigin = "https://bafybeiaohcwssw43cec54rr23jvxkfki2tttywyvvrru6t4gejq6mlcmhy.ipfs.infura-ipfs.io/";
+const defaultSnapOrigin = "https://bafybeiazeik53jn6p664ex72ryjmshdap2fbylb7tb57dooxp4zvb32uju.ipfs.infura-ipfs.io/";
 const defaultSnapId = `wallet_plugin_${defaultSnapOrigin}`;
 
 export type MetamaskFilecoinSnap = MFSnap;

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodefactory/filsnap",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "(Apache-2.0 AND MIT)",
   "description": "Filsnap - Metamask snap to interact with Filecoin dapps.",
   "private": false,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodefactory/filsnap-types",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "types": "./index.d.ts",
   "license": "(Apache-2.0 AND MIT)",
   "author": "NodeFactory <info@nodefactory.io>",


### PR DESCRIPTION
Published new version of `types`, `snap` and `adapter` packages `0.2.2`

### Changes
- #71 

### Fixed
- #69 
- Wrong version of snap published on IPFS
