### PR TITLE
Address upgrades

### DIFF
--- a/packages/example/src/containers/Dashboard/Dashboard.tsx
+++ b/packages/example/src/containers/Dashboard/Dashboard.tsx
@@ -34,10 +34,6 @@ export const Dashboard = () => {
             await api.configure({network: selectedNetwork});
             setNetwork(selectedNetwork);
             setMessages(await api.getMessages());
-            //
-            setAddress(await api.getAddress());
-            setPublicKey(await api.getPublicKey());
-            setBalance(await api.getBalance());
         }
     };
 

--- a/packages/example/src/containers/Dashboard/Dashboard.tsx
+++ b/packages/example/src/containers/Dashboard/Dashboard.tsx
@@ -23,7 +23,7 @@ export const Dashboard = () => {
 
     const [balanceChange, setBalanceChange] = useState<boolean>(false);
 
-    const [network, setNetwork] = useState<"f" | "t" >("t");
+    const [network, setNetwork] = useState<"f" | "t" >("f");
 
     const [api, setApi] = useState<FilecoinSnapApi|null>(null);
 
@@ -34,6 +34,10 @@ export const Dashboard = () => {
             await api.configure({network: selectedNetwork});
             setNetwork(selectedNetwork);
             setMessages(await api.getMessages());
+            //
+            setAddress(await api.getAddress());
+            setPublicKey(await api.getPublicKey());
+            setBalance(await api.getBalance());
         }
     };
 
@@ -99,11 +103,11 @@ export const Dashboard = () => {
                     <Box m="1rem" alignSelf="baseline">
                         <InputLabel>Network</InputLabel>
                         <Select
-                            defaultValue={"t"}
+                            defaultValue={"f"}
                             onChange={handleNetworkChange}
                         >
                             <MenuItem value={"t"}>Testnet</MenuItem>
-                            {/*<MenuItem value={"f"}>Mainnet</MenuItem> - mainnet not supported*/}
+                            <MenuItem value={"f"}>Mainnet</MenuItem>
                         </Select>
                     </Box>
                     <Grid container spacing={3} alignItems="stretch">

--- a/packages/example/src/services/metamask.ts
+++ b/packages/example/src/services/metamask.ts
@@ -27,9 +27,9 @@ export async function installFilecoinSnap(): Promise<SnapInitializationResponse>
         console.log("installing snap");
         let metamaskFilecoinSnap;
         if (process.env.REACT_APP_SNAP === 'local') {
-            metamaskFilecoinSnap = await enableFilecoinSnap({network: "t"}, localOrigin);
+            metamaskFilecoinSnap = await enableFilecoinSnap({network: "f"}, localOrigin);
         } else {
-            metamaskFilecoinSnap = await enableFilecoinSnap({network: "t"});
+            metamaskFilecoinSnap = await enableFilecoinSnap({network: "f"});
         }
         isInstalled = true;
         console.log("Snap installed!!");

--- a/packages/snap/src/configuration/predefined.ts
+++ b/packages/snap/src/configuration/predefined.ts
@@ -5,11 +5,11 @@ export const filecoinMainnetConfiguration: SnapConfig = {
   network: "f",
   rpc: {
     token: "",
-    url: "",
+    url: "https://api.node.glif.io",
   },
   unit: {
     decimals: 6,
-    image: `https://svgshare.com/i/M4s.svg`,
+    image: `https://cryptologos.cc/logos/filecoin-fil-logo.svg?v=007`,
     symbol: "FIL"
   }
 };
@@ -20,14 +20,14 @@ export const filecoinTestnetConfiguration: SnapConfig = {
   network: "t",
   rpc: {
     token: "",
-    url: `http://node.glif.io/space05/lotus/rpc/v0`
+    url: `https://api.node.glif.io`
   },
   unit: {
     decimals: 6,
-    image: `https://svgshare.com/i/M4s.svg`,
+    image: `https://cryptologos.cc/logos/filecoin-fil-logo.svg?v=007`,
     symbol: "FIL",
     // custom view url ?
   }
 };
 
-export const defaultConfiguration: SnapConfig = filecoinTestnetConfiguration;
+export const defaultConfiguration: SnapConfig = filecoinMainnetConfiguration;


### PR DESCRIPTION
### Changes
- Add mainet configuration, this configuration uses `m/44'/461'/0'/0/0` derivation path and generates addresses with prefix `f`
- Set mainet as default network in example (this configuration also works with current testnet - _SpaceRace_)
- Change URL for FIL logo svg image to `https://cryptologos.cc/logos/filecoin-fil-logo.svg?v=007`

### Issues
closes #73 
closes #74 